### PR TITLE
fix: rag_pipeline.py의 Page Content 반환 부분 제거

### DIFF
--- a/fastapi-google-stt/app/services/rag_pipeline.py
+++ b/fastapi-google-stt/app/services/rag_pipeline.py
@@ -47,14 +47,14 @@ async def answer_question(query: str, script_id: str, collection_num: int=0):
         async for chunk in rag_chain.astream(query):
             yield f"data: {chunk}\n\n"
         
-        # 5. 스트리밍 완료 후 소스 문서 전송
-        docs = await retriever.ainvoke(query)
-        for doc in docs:
-            # source_info = {
-            #     "content": doc.page_content,
-            #     "metadata": doc.metadata
-            # }
-            yield f"data: Content: {doc.page_content}\n\n"
+        # # 5. 스트리밍 완료 후 소스 문서 전송
+        # docs = await retriever.ainvoke(query)
+        # for doc in docs:
+        #     # source_info = {
+        #     #     "content": doc.page_content,
+        #     #     "metadata": doc.metadata
+        #     # }
+        #     yield f"data: Content: {doc.page_content}\n\n"
             
     except Exception as e:
         yield f"data: Error: {str(e)}\n\n"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Disabled the streaming of source documents after the main response. Only the main response and error messages will now be streamed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->